### PR TITLE
Reject unsupported password arguments

### DIFF
--- a/fixtures.go
+++ b/fixtures.go
@@ -6,7 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 
-	"github.com/golang/go/src/log"
+	"log"
 )
 
 // openssl genrsa -out rsa-pkcs1.pem 1024

--- a/fixtures.go
+++ b/fixtures.go
@@ -1,5 +1,14 @@
 package keyremix
 
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+
+	"github.com/golang/go/src/log"
+)
+
 // openssl genrsa -out rsa-pkcs1.pem 1024
 var rsaPkcs1Pem = `-----BEGIN RSA PRIVATE KEY-----
 MIICXgIBAAKBgQC9iLFZYoYVNVBPl32eTXMTqDYx+R9NfbewxxUxF8EMvnA7KJ1h
@@ -399,4 +408,19 @@ var rsaP12 = []byte{
 	0xbd, 0x3b, 0x7a, 0x3d, 0xe8, 0xdd, 0x4a, 0x04,
 	0x08, 0x5a, 0x93, 0x86, 0xf1, 0xc4, 0xfc, 0x06,
 	0x9c, 0x02, 0x02, 0x08, 0x00,
+}
+
+var rsa1024 *rsa.PrivateKey
+var ecdsa384 *ecdsa.PrivateKey
+
+func generateTestKeys() {
+	var err error
+	if rsa1024 == nil {
+		if rsa1024, err = rsa.GenerateKey(rand.Reader, 1024); err != nil {
+			log.Panicf("rsa.GenerateKey: %v", err)
+		}
+		if ecdsa384, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader); err != nil {
+			log.Panicf("ecdsa.GenerateKey: %v", err)
+		}
+	}
 }

--- a/jwk.go
+++ b/jwk.go
@@ -3,15 +3,20 @@ package keyremix
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/lestrrat-go/jwx/jwk"
 	"strconv"
 	"strings"
+
+	"github.com/lestrrat-go/jwx/jwk"
 )
 
 type jwkFormat struct {
 }
 
 func (*jwkFormat) Serialize(key interface{}, args map[string]string) (output []byte, err error) {
+	if _, ok := args["password"]; ok {
+		err = ErrNotImplemented
+		return
+	}
 	var jkey jwk.Key
 	if jkey, err = jwk.New(key); err != nil {
 		return

--- a/keyremix.go
+++ b/keyremix.go
@@ -56,6 +56,9 @@ var ErrUnsuitableKeyType = errors.New("unsuitable key type")
 // ErrPasswordRequired is returned when a password is required.
 var ErrPasswordRequired = errors.New("password required")
 
+// ErrNotImplemented is returned when functionality is missing.
+var ErrNotImplemented = errors.New("not implemented")
+
 // KeyFormats is the collection of known key formats.
 var KeyFormats = map[string]KeyFormat{}
 

--- a/pkcs1.go
+++ b/pkcs1.go
@@ -11,6 +11,10 @@ type pkcs1 struct {
 }
 
 func (p *pkcs1) Serialize(key interface{}, args map[string]string) (output []byte, err error) {
+	if _, ok := args["password"]; ok {
+		err = ErrNotImplemented
+		return
+	}
 	var name string
 	switch k := key.(type) {
 	case *rsa.PrivateKey:

--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -46,16 +46,14 @@ func TestPkcs12(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("Serialize", func(t *testing.T) {
+		generateTestKeys()
 		var err error
-		var key *rsa.PrivateKey
-		key, err = rsa.GenerateKey(rand.Reader, 1024)
-		require.NoError(t, err)
 		// Need a certificate too
 		template := x509.Certificate{
 			SerialNumber: big.NewInt(1),
 		}
 		var cert []byte
-		cert, err = x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key)
+		cert, err = x509.CreateCertificate(rand.Reader, &template, &template, rsa1024.Public(), rsa1024)
 		require.NoError(t, err)
 		b := pem.Block{Type: "CERTIFICATE", Headers: nil, Bytes: cert}
 		certPem := pem.EncodeToMemory(&b)
@@ -66,7 +64,7 @@ func TestPkcs12(t *testing.T) {
 			"password":    "insecure",
 			"certificate": "TestPkcs12Serialize.crt",
 		}
-		output, err = Pkcs12.Serialize(key, args)
+		output, err = Pkcs12.Serialize(rsa1024, args)
 		require.NoError(t, err)
 		os.Remove("TestPkcs12Serialize.crt")
 		var key2i interface{}
@@ -74,11 +72,11 @@ func TestPkcs12(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(rest))
 		key2 := key2i.(*rsa.PrivateKey)
-		assert.Equal(t, key.N, key2.N)
-		assert.Equal(t, key.E, key2.E)
-		assert.Equal(t, key.D, key2.D)
-		assert.Equal(t, key.Primes[0], key2.Primes[0])
-		assert.Equal(t, key.Primes[1], key2.Primes[1])
+		assert.Equal(t, rsa1024.N, key2.N)
+		assert.Equal(t, rsa1024.E, key2.E)
+		assert.Equal(t, rsa1024.D, key2.D)
+		assert.Equal(t, rsa1024.Primes[0], key2.Primes[0])
+		assert.Equal(t, rsa1024.Primes[1], key2.Primes[1])
 		var writtenCert []byte
 		writtenCert, err = ioutil.ReadFile("TestPkcs12Serialize.crt")
 		require.NoError(t, err)

--- a/pkcs1_test.go
+++ b/pkcs1_test.go
@@ -1,7 +1,6 @@
 package keyremix
 
 import (
-	"crypto/rand"
 	"crypto/rsa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,23 +34,21 @@ func TestPkcs1Pem(t *testing.T) {
 		assert.Equal(t, UnambiguousFit, fit)
 	})
 	t.Run("Serialize", func(t *testing.T) {
+		generateTestKeys()
 		var err error
-		var key *rsa.PrivateKey
-		key, err = rsa.GenerateKey(rand.Reader, 1024)
-		require.NoError(t, err)
 		var rest, output []byte
-		output, err = Pkcs1Pem.Serialize(key, nil)
+		output, err = Pkcs1Pem.Serialize(rsa1024, nil)
 		require.NoError(t, err)
 		var key2i interface{}
 		key2i, rest, err = Pkcs1Pem.Deserialize(output, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(rest))
 		key2 := key2i.(*rsa.PrivateKey)
-		assert.Equal(t, key.N, key2.N)
-		assert.Equal(t, key.E, key2.E)
-		assert.Equal(t, key.D, key2.D)
-		assert.Equal(t, key.Primes[0], key2.Primes[0])
-		assert.Equal(t, key.Primes[1], key2.Primes[1])
+		assert.Equal(t, rsa1024.N, key2.N)
+		assert.Equal(t, rsa1024.E, key2.E)
+		assert.Equal(t, rsa1024.D, key2.D)
+		assert.Equal(t, rsa1024.Primes[0], key2.Primes[0])
+		assert.Equal(t, rsa1024.Primes[1], key2.Primes[1])
 	})
 }
 
@@ -81,22 +78,20 @@ func TestPkcs1Der(t *testing.T) {
 		assert.Equal(t, AmbiguousFit, fit)
 	})
 	t.Run("Serialize", func(t *testing.T) {
+		generateTestKeys()
 		var err error
-		var key *rsa.PrivateKey
-		key, err = rsa.GenerateKey(rand.Reader, 1024)
-		require.NoError(t, err)
 		var rest, output []byte
-		output, err = Pkcs1Der.Serialize(key, nil)
+		output, err = Pkcs1Der.Serialize(rsa1024, nil)
 		require.NoError(t, err)
 		var key2i interface{}
 		key2i, rest, err = Pkcs1Der.Deserialize(output, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(rest))
 		key2 := key2i.(*rsa.PrivateKey)
-		assert.Equal(t, key.N, key2.N)
-		assert.Equal(t, key.E, key2.E)
-		assert.Equal(t, key.D, key2.D)
-		assert.Equal(t, key.Primes[0], key2.Primes[0])
-		assert.Equal(t, key.Primes[1], key2.Primes[1])
+		assert.Equal(t, rsa1024.N, key2.N)
+		assert.Equal(t, rsa1024.E, key2.E)
+		assert.Equal(t, rsa1024.D, key2.D)
+		assert.Equal(t, rsa1024.Primes[0], key2.Primes[0])
+		assert.Equal(t, rsa1024.Primes[1], key2.Primes[1])
 	})
 }

--- a/pkcs8.go
+++ b/pkcs8.go
@@ -12,6 +12,10 @@ type pkcs8 struct {
 }
 
 func (p *pkcs8) Serialize(key interface{}, args map[string]string) (output []byte, err error) {
+	if _, ok := args["password"]; ok {
+		err = ErrNotImplemented
+		return
+	}
 	var name string
 	switch k := key.(type) {
 	case *rsa.PrivateKey:

--- a/pkcs8_test.go
+++ b/pkcs8_test.go
@@ -2,8 +2,6 @@ package keyremix
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,23 +36,21 @@ func TestPkcs8Pem(t *testing.T) {
 			assert.Equal(t, UnambiguousFit, fit)
 		})
 		t.Run("Serialize", func(t *testing.T) {
+			generateTestKeys()
 			var err error
-			var key *rsa.PrivateKey
-			key, err = rsa.GenerateKey(rand.Reader, 1024)
-			require.NoError(t, err)
 			var rest, output []byte
-			output, err = Pkcs8Pem.Serialize(key, nil)
+			output, err = Pkcs8Pem.Serialize(rsa1024, nil)
 			require.NoError(t, err)
 			var key2i interface{}
 			key2i, rest, err = Pkcs8Pem.Deserialize(output, nil)
 			require.NoError(t, err)
 			assert.Equal(t, 0, len(rest))
 			key2 := key2i.(*rsa.PrivateKey)
-			assert.Equal(t, key.N, key2.N)
-			assert.Equal(t, key.E, key2.E)
-			assert.Equal(t, key.D, key2.D)
-			assert.Equal(t, key.Primes[0], key2.Primes[0])
-			assert.Equal(t, key.Primes[1], key2.Primes[1])
+			assert.Equal(t, rsa1024.N, key2.N)
+			assert.Equal(t, rsa1024.E, key2.E)
+			assert.Equal(t, rsa1024.D, key2.D)
+			assert.Equal(t, rsa1024.Primes[0], key2.Primes[0])
+			assert.Equal(t, rsa1024.Primes[1], key2.Primes[1])
 		})
 	})
 	t.Run("EC", func(t *testing.T) {
@@ -83,22 +79,20 @@ func TestPkcs8Pem(t *testing.T) {
 			assert.Equal(t, UnambiguousFit, fit)
 		})
 		t.Run("Serialize", func(t *testing.T) {
+			generateTestKeys()
 			var err error
-			var key *ecdsa.PrivateKey
-			key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-			require.NoError(t, err)
 			var rest, output []byte
-			output, err = Pkcs8Pem.Serialize(key, nil)
+			output, err = Pkcs8Pem.Serialize(ecdsa384, nil)
 			require.NoError(t, err)
 			var key2i interface{}
 			key2i, rest, err = Pkcs8Pem.Deserialize(output, nil)
 			require.NoError(t, err)
 			assert.Equal(t, 0, len(rest))
 			key2 := key2i.(*ecdsa.PrivateKey)
-			assert.Equal(t, key.D, key2.D)
-			assert.Equal(t, key.Curve, key2.Curve)
-			assert.Equal(t, key.X, key2.X)
-			assert.Equal(t, key.Y, key2.Y)
+			assert.Equal(t, ecdsa384.D, key2.D)
+			assert.Equal(t, ecdsa384.Curve, key2.Curve)
+			assert.Equal(t, ecdsa384.X, key2.X)
+			assert.Equal(t, ecdsa384.Y, key2.Y)
 		})
 	})
 }
@@ -130,21 +124,18 @@ func TestPkcs8Der(t *testing.T) {
 	})
 	t.Run("Serialize", func(t *testing.T) {
 		var err error
-		var key *rsa.PrivateKey
-		key, err = rsa.GenerateKey(rand.Reader, 1024)
-		require.NoError(t, err)
 		var rest, output []byte
-		output, err = Pkcs8Der.Serialize(key, nil)
+		output, err = Pkcs8Der.Serialize(rsa1024, nil)
 		require.NoError(t, err)
 		var key2i interface{}
 		key2i, rest, err = Pkcs8Der.Deserialize(output, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(rest))
 		key2 := key2i.(*rsa.PrivateKey)
-		assert.Equal(t, key.N, key2.N)
-		assert.Equal(t, key.E, key2.E)
-		assert.Equal(t, key.D, key2.D)
-		assert.Equal(t, key.Primes[0], key2.Primes[0])
-		assert.Equal(t, key.Primes[1], key2.Primes[1])
+		assert.Equal(t, rsa1024.N, key2.N)
+		assert.Equal(t, rsa1024.E, key2.E)
+		assert.Equal(t, rsa1024.D, key2.D)
+		assert.Equal(t, rsa1024.Primes[0], key2.Primes[0])
+		assert.Equal(t, rsa1024.Primes[1], key2.Primes[1])
 	})
 }

--- a/pkix.go
+++ b/pkix.go
@@ -12,6 +12,10 @@ type pkix struct {
 }
 
 func (p *pkix) Serialize(key interface{}, args map[string]string) (output []byte, err error) {
+	if _, ok := args["password"]; ok {
+		err = ErrNotImplemented
+		return
+	}
 	var name string
 	switch k := key.(type) {
 	case *rsa.PublicKey:

--- a/text.go
+++ b/text.go
@@ -18,6 +18,10 @@ type value struct {
 }
 
 func (p *text) Serialize(key interface{}, args map[string]string) (output []byte, err error) {
+	if _, ok := args["password"]; ok {
+		err = ErrNotImplemented
+		return
+	}
 	f := &bytes.Buffer{}
 
 	var ok bool


### PR DESCRIPTION
The `pkcs12` format takes a `password` argument. A user may reasonably guess from this that all the key types support passwords, but if they do so then they will be severely disappointed, as their private keys will not be encrypted as they expect.

This PR rejects unsupported `password` arguments, and (in the other commit) also cuts down on the amount of redundant key generation in the tests.